### PR TITLE
feat(user): support location query

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,7 +23,7 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          port: ${{ secrets.DEPLOY_PORT }}
+          port: ${{ secrets.PORT }}
           script: |
             cd penpalmap
             docker login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "penpalmap-api",
-      "version": "1.12.0",
+      "version": "1.17.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^10.0.0",

--- a/src/user/dto/query-user.dto.ts
+++ b/src/user/dto/query-user.dto.ts
@@ -1,4 +1,14 @@
-import { IsEmail, IsIn, IsOptional, IsUUID, Length } from 'class-validator';
+import {
+  IsEmail,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsUUID,
+  Length,
+  Max,
+  Min,
+} from 'class-validator';
 import { PaginatedQueryDto } from '../../shared/pagination/paginated-query.dto';
 import User from '../user.model';
 import { OrderDto } from '../../shared/pagination/order.dto';
@@ -17,6 +27,26 @@ export class QueryUserDto
   @IsOptional()
   @Length(1, 65535)
   googleId?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Transform(({ value }) => parseFloat(value), { toClassOnly: true })
+  @Min(-90)
+  @Max(90)
+  latitude?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Transform(({ value }) => parseFloat(value), { toClassOnly: true })
+  @Min(-180)
+  @Max(180)
+  longitude?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Transform(({ value }) => parseFloat(value), { toClassOnly: true })
+  @IsPositive()
+  radius?: number;
 
   @IsOptional()
   @IsIn(['points'])


### PR DESCRIPTION
With this PR, you can now query users with `longitude`, `latitude` and `radius` (in km). These fields are optional but all three must be passed in order to use location-based queries.

Example:

```
/api/users?latitude=43.6185123&longitude=3.8767429&radius=0.01 => should return Montpellier based users
```
```
/api/users?latitude=48.866667&longitude=2.333333&radius=0.01 => should return Paris based users
```